### PR TITLE
Move argument from hard coded value to command line argument

### DIFF
--- a/src/euclid_useful_stuff/migration/migrate_project.py
+++ b/src/euclid_useful_stuff/migration/migrate_project.py
@@ -8,30 +8,67 @@ main script that migrates a euclid repo from lousy svn to git
 <seealso>
 </seealso>
 """
+
+import argparse
+import re
 import migration
 from migration import run_command
 
-# some project paths
-# project_path = 'EC/SGS/PF/EuclidLib/ScientificLibs/LibCatalog'
-project_path = 'EC/SGS/ST/4-2-09-TOOLS/Astromatic/Swarp'
-# project_path = 'EC/SGS/OU/NIR/NIRPipe/WP2500_CR'
-# project_path = 'EC/SGS/SDC/I/Projects/CTEigen'
-# project_path = 'EC/SGS/SDC/CH/Projects/Elements'
+def valid_url(url):
+    """ Check if the given URL already exists
+    """
+    regex = re.compile(
+        r'^(?:http|ftp)s?://' # http:// or https://
+        r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|' #domain...
+        r'localhost|' #localhost...
+        r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})' # ...or ip
+        r'(?::\d+)?' # optional port
+        r'(?:/?|[/?]\S+)$', re.IGNORECASE)
 
-# path to script that gets authors list. This can be obtained from
-path_to_svn_migration_script = '~/bin/svn-migration-scripts.jar'
-
-# path to the svn and git repos
-euclid_svn = 'http://euclid.esac.esa.int/svn'
-euclid_git = 'http://euclid-git.roe.ac.uk/mkazandj'
-
-# get the authros list
-# migration.get_authors(path_to_svn_migration_script, euclid_svn)
-
-# migrate the project
-migration.migrate_project(base_svn_url=euclid_svn,
-                          base_git_url=euclid_git,
-                          relative_project_url=project_path)
+    if regex.match(url):
+        return url
+    else:
+        raise IOError("URL '%s' is not well formatted" % url)
 
 
-print('done')
+def migrate_project(base_svn_url, base_git_url, relative_project_url):
+    """ Migrate a project from SVN to Git
+
+    :param base_svn_url: The base url of the svn repo
+    :param base_git_url: The base url of the git repo
+    :param relative_project_url: The relative path of the project on the svn
+     repo.
+    """
+    # migrate the project
+    migration.migrate_project(base_svn_url=base_svn_url,
+                              base_git_url=base_git_url,
+                              relative_project_url=relative_project_url)
+
+
+if __name__ == "__main__":
+    # Create argument parser
+    parser = argparse.ArgumentParser(description="Euclid migration script from SVN to Git")
+
+    # Add arguments to parser
+    parser.add_argument("base_svn_url",
+                        action="store",
+                        type=valid_url,
+                        metavar="URL",
+                        help='Base SVN URL, must be equal to "http://euclid.esac.esa.int/svn"')
+    parser.add_argument("base_git_url",
+                        action="store",
+                        type=valid_url,
+                        metavar="URL",
+                        help='Base Git URL, it must begins with "http://euclid-git.roe.ac.uk"')
+    parser.add_argument("relative_project_url",
+                        action="store",
+                        type=str,
+                        metavar="PATH",
+                        help='Relative project URL in the SVN repository. Eg: "EC/SGS/ST/4-2-09-TOOLS/Astromatic/Swarp"')
+
+    # Parse command line
+    args = parser.parse_args()
+
+    # Run main function for project migration
+    migrate_project(args.base_svn_url, args.base_git_url, args.relative_project_url)
+

--- a/src/euclid_useful_stuff/migration/migration.py
+++ b/src/euclid_useful_stuff/migration/migration.py
@@ -76,6 +76,9 @@ def migrate_project(base_svn_url,
     # cleanup
     delete_all_remotes(project_name)
 
+    # ends
+    print(">>> End of migration from '%s/%s' to '%s'" % (base_svn_url, relative_project_url, base_git_url))
+
 def reset_master_to_first_commit(project):
     """reset the master branch to the root commit
 

--- a/src/euclid_useful_stuff/migration/migration.py
+++ b/src/euclid_useful_stuff/migration/migration.py
@@ -120,6 +120,9 @@ def run_command(cmd, *args, **kwargs):
     process.wait()
     stdout, stderr = process.communicate()
     print(stdout)
+    if stderr:
+        print(stderr)
+        raise TypeError("An error occur running the command: '%s'" % cmd)
     return stdout
 
 def get_authors(path_to_svn_migration_script, repo_url):


### PR DESCRIPTION
I edit the [migrate_project.py](https://github.com/mherkazandjian/euclid-useful-stuff/blob/master/src/euclid_useful_stuff/migration/migrate_project.py) script to read argument parser from command line instead of using internal hard coded values.

I also add a test of stderr and in case of error I stop the script (no need to go further if something wrong happened).

Last things, I improve the final message after the script ends.
